### PR TITLE
id.chol_PermReCaus

### DIFF
--- a/R/bootstrap_mb.R
+++ b/R/bootstrap_mb.R
@@ -216,7 +216,7 @@ mb.boot <- function(x, design = "recursive", b.length = 15, n.ahead = 20, nboot 
                                   crit = x$crit),
                          error = function(e) NULL)
       }else if(x$method == "Cholesky"){
-        temp <- id.chol(varb)
+        temp <- id.chol(varb, order_k = x$order_k)
       }
     } else if (design == "fixed") {
       Ystar <- t(A %*% Z + Ustar1)
@@ -245,7 +245,7 @@ mb.boot <- function(x, design = "recursive", b.length = 15, n.ahead = 20, nboot 
                                   crit = x$crit),
                          error = function(e) NULL)
       }else if(x$method == "Cholesky"){
-        temp <- id.chol(varb)
+        temp <- id.chol(varb, order_k = x$order_k)
       }else{
         temp <- tryCatch(id.st_boot(varb, c_fix = x$est_c, transition_variable = x$transition_variable, restriction_matrix = x$restriction_matrix,
                                     gamma_fix = x$est_g, max.iter = x$iteration, crit = 0.01, Z = Z),

--- a/R/bootstrap_wild.R
+++ b/R/bootstrap_wild.R
@@ -198,7 +198,7 @@ wild.boot <- function(x, design = "fixed", distr = "rademacher", n.ahead = 20,
                                   crit = x$crit),
                          error = function(e) NULL)
       }else if(x$method == "Cholesky"){
-        temp <- id.chol(varb)
+        temp <- id.chol(varb, order_k = x$order_k)
       }else{
         temp <- tryCatch(id.st_boot(varb, c_fix = x$est_c, transition_variable = x$transition_variable, restriction_matrix = x$restriction_matrix,
                                     gamma_fix = x$est_g, max.iter = x$iteration, crit = 0.01, Z = Z),
@@ -258,7 +258,7 @@ wild.boot <- function(x, design = "fixed", distr = "rademacher", n.ahead = 20,
                                   crit = x$crit),
                          error = function(e) NULL)
       }else if(x$method == "Cholesky"){
-        temp <- id.chol(varb)
+        temp <- id.chol(varb, order_k = x$order_k)
       }
     }
 


### PR DESCRIPTION
Change the causal ordering in the instantaneous effects without permuting variables and re-estimating the VAR model. (Updated files according to changes in https://github.com/alexanderlange53/svars/commit/8df451d142b0ebb53ccd71273c49a2e34e5cdfde)